### PR TITLE
Add missing operator-config ConfigMap for e2e tests

### DIFF
--- a/components/manifests/overlays/e2e/kustomization.yaml
+++ b/components/manifests/overlays/e2e/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - test-user.yaml
 - frontend-ingress.yaml
 - backend-ingress.yaml
+- operator-config.yaml
 
 # Patches for e2e environment
 patches:

--- a/components/manifests/overlays/e2e/operator-config.yaml
+++ b/components/manifests/overlays/e2e/operator-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-config
+  labels:
+    app: agentic-operator
+    deployment-type: e2e
+data:
+  # Vertex AI Configuration - Disabled for e2e testing
+  CLAUDE_CODE_USE_VERTEX: "0"
+  CLOUD_ML_REGION: ""
+  ANTHROPIC_VERTEX_PROJECT_ID: ""
+  GOOGLE_APPLICATION_CREDENTIALS: ""


### PR DESCRIPTION
The operator deployment requires Vertex AI configuration from a ConfigMap. Production and local-dev overlays have this, but e2e was missing it, causing the operator pod to fail to start in GitHub Actions e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)